### PR TITLE
Assign pull request author automatically

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,16 @@
+name: Assignment management
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    name: Auto-assign pull request author
+    if: github.repository_owner == 'consul'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.4.0


### PR DESCRIPTION
## Objectives

* Automate a process we've been doing manually for years
* Have a bot assigning pull requests so people don't take the blame for doing so :joy:

## Notes

The reason why we're assigning the author is it makes it easy to filter pull requests by assignee on our kanban; it isn't so easy (actually, might be impossible) to filter by author.