### PR TITLE
Install specific nodejs version

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -18,6 +18,7 @@
   roles:
     - folder_structure
     - ruby
+    - nodejs
     - rails
     - email
     - queue

--- a/galaxy/yatesr.timezone/tasks/main.yml
+++ b/galaxy/yatesr.timezone/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: timezone.yml
+- include_tasks: timezone.yml

--- a/group_vars/all
+++ b/group_vars/all
@@ -45,6 +45,13 @@ smtp_authentication: "plain"
 #LetsEncrypt
 #letsencrypt_email: "your_email@example.com"
 
+# Node.js
+fnm_dir: "{{ home_dir }}/.fnm"
+fnm_command: "export PATH=\"{{ fnm_dir }}/:$PATH\" && eval \"$(fnm env)\""
+
+# RVM
+rvm_command: "source {{ home_dir }}/.rvm/scripts/rvm"
+
 # Errbit
 errbit: False
 errbit_dir: "{{ home_dir }}/errbit"

--- a/roles/errbit/tasks/main.yml
+++ b/roles/errbit/tasks/main.yml
@@ -146,7 +146,7 @@
     replace: '  errbit_host: "https://{{ errbit_domain }}"'
 
 - name: Restart CONSUL DEMOCRACY
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV={{ env }} bin/rails restart"
+  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bin/rails restart RAILS_ENV={{ env }}"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash

--- a/roles/errbit/tasks/main.yml
+++ b/roles/errbit/tasks/main.yml
@@ -35,7 +35,7 @@
     executable: /bin/bash
 
 - name: Install libv8-node for the right platform
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && gem install libv8-node --version '{{ libv8_version.stdout }}' --platform x86_64-linux-libc"
+  shell: "{{ rvm_command }} && gem install libv8-node --version '{{ libv8_version.stdout }}' --platform x86_64-linux-libc"
   args:
     chdir: "{{ errbit_dir }}"
     executable: /bin/bash
@@ -48,13 +48,13 @@
     executable: /bin/bash
 
 - name: Install the mini_racer gem
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && gem install mini_racer --version '{{ mini_racer_version.stdout }}'"
+  shell: "{{ rvm_command }} && gem install mini_racer --version '{{ mini_racer_version.stdout }}'"
   args:
     chdir: "{{ errbit_dir }}"
     executable: /bin/bash
 
 - name: Install Errbit dependencies
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle install"
+  shell: "{{ rvm_command }} && bundle install"
   args:
     chdir: "{{ errbit_dir }}"
     executable: /bin/bash
@@ -81,7 +81,7 @@
 - when: not existing_secret_key_base.found
   block:
     - name: Generate secret key
-      shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rake secret"
+      shell: "{{ rvm_command }} && bin/rake secret"
       register: secret_key_base
       args:
         chdir: "{{ errbit_dir }}"
@@ -93,13 +93,13 @@
         line: "SECRET_KEY_BASE={{ secret_key_base.stdout }}"
 
     - name: Setup Errbit
-      shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV={{ env }} bin/rake errbit:bootstrap"
+      shell: "{{ rvm_command }} && RAILS_ENV={{ env }} bin/rake errbit:bootstrap"
       args:
         chdir: "{{ errbit_dir }}"
         executable: /bin/bash
 
     - name: Precompile Errbit assets
-      shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV={{ env }} bin/rake assets:precompile"
+      shell: "{{ rvm_command }} && RAILS_ENV={{ env }} bin/rake assets:precompile"
       args:
         chdir: "{{ errbit_dir }}"
         executable: /bin/bash
@@ -121,7 +121,7 @@
     enabled: true
 
 - name: Create app if it does not exist
-  shell: 'source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rails runner -e {{ env }} "App.create(name: \"{{ domain }}\")"'
+  shell: '{{ rvm_command }} && bin/rails runner -e {{ env }} "App.create(name: \"{{ domain }}\")"'
   args:
     chdir: "{{ errbit_dir }}"
     executable: /bin/bash

--- a/roles/errbit/templates/errbit.service
+++ b/roles/errbit/templates/errbit.service
@@ -7,7 +7,7 @@ After=mongodb.service network.target
 Type=simple
 WorkingDirectory={{ errbit_dir }}
 Environment=RAILS_ENV={{ env }}
-ExecStart=/bin/bash -lc 'source {{ home_dir }}/.rvm/scripts/rvm && bundle exec puma -C {{ errbit_dir }}/config/puma.default.rb -e {{ env }}'
+ExecStart=/bin/bash -lc '{{ rvm_command }} && bundle exec puma -C {{ errbit_dir }}/config/puma.default.rb -e {{ env }}'
 Restart=always
 User={{ errbit_user }}
 Group={{ errbit_group }}

--- a/roles/folder_structure/tasks/main.yml
+++ b/roles/folder_structure/tasks/main.yml
@@ -22,7 +22,7 @@
         state: directory
 
     - name: Create first release
-      shell: "git archive 2.0.1 | /usr/bin/env tar -x -f - -C {{ first_release_dir }}"
+      shell: "git archive e0aee199e487 | /usr/bin/env tar -x -f - -C {{ first_release_dir }}"
       args:
         chdir: "{{ consul_dir }}/repo"
 

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -18,6 +18,10 @@
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
+  register: fnm_install_result
+  until: "fnm_install_result is not failed"
+  retries: 10
+  delay: 10
 
 - name: Install Node packages
   shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec npm install --production"

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Install fnm
+  shell: |
+    curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "{{ fnm_dir }}"
+  args:
+    chdir: "{{ home_dir }}"
+    executable: /bin/bash
+    creates: "{{ fnm_dir }}/fnm"
+
+- name: Read Node.js version
+  shell: "cat .node-version"
+  args:
+    chdir: "{{ release_dir }}"
+  register: node_version
+
+- name: Install nodejs via fnm
+  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm install {{ node_version.stdout }}"
+  args:
+    chdir: "{{ release_dir }}"
+    executable: /bin/bash
+
+- name: Install Node packages
+  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec npm install --production"
+  args:
+    chdir: "{{ release_dir }}"
+    executable: /bin/bash

--- a/roles/puma/tasks/main.yml
+++ b/roles/puma/tasks/main.yml
@@ -23,7 +23,7 @@
   when: puma_process.stat.exists == True
 
 - name: Start puma
-  shell: "source {{ home_dir }}/.rvm/scripts/rvm && bundle exec puma -C {{ release_dir }}/config/puma/{{ env }}.rb -e {{ env }} -d"
+  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bundle exec puma -C {{ release_dir }}/config/puma/{{ env }}.rb -e {{ env }} -d"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash

--- a/roles/queue/tasks/main.yml
+++ b/roles/queue/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Start DelayedJobs queue
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV={{ env }} bin/delayed_job -m -n 2 restart"
+  shell: "{{ fnm_command }} && {{ rvm_command }} && RAILS_ENV={{ env }} fnm exec bin/delayed_job -m -n 2 restart"
   args:
     executable: /bin/bash
     chdir: "{{ release_dir }}"

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -60,7 +60,7 @@
     replace: '{{ env }}:\n  # secret_key_base: ""\n  server_name: "{{ server_hostname }}"'
 
 - name: Generate secret key
-  shell: "source {{ home_dir }}/.rvm/scripts/rvm && bin/rake secret RAILS_ENV={{ env }}"
+  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bin/rake secret RAILS_ENV={{ env }}"
   register: secret_key_base
   args:
     chdir: "{{ release_dir }}"
@@ -80,25 +80,25 @@
   when: domain is not defined
 
 - name: Create Database
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rake db:migrate RAILS_ENV={{ env }}"
+  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bin/rake db:migrate RAILS_ENV={{ env }}"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
 
 - name: Load configuration seeds
-  shell: "source /home/{{ deploy_user}}/.rvm/scripts/rvm && bin/rake db:seed RAILS_ENV={{ env }}"
+  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bin/rake db:seed RAILS_ENV={{ env }}"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
 
 - name: Precompile assets
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rake assets:precompile RAILS_ENV={{ env }}"
+  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bin/rake assets:precompile RAILS_ENV={{ env }}"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
 
 - name: Update crontab with whenever
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle exec whenever --update-crontab {{ app_name }} --set environment={{ env }}"
+  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bundle exec whenever --update-crontab {{ app_name }} --set environment={{ env }}"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Configure Bundler path
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle config --local path {{ shared_dir }}/bundle"
+  shell: "{{ rvm_command }} && bundle config --local path {{ shared_dir }}/bundle"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
 
 - name: Configure Bundler environments
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle config --local without development:test"
+  shell: "{{ rvm_command }} && bundle config --local without development:test"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
@@ -26,7 +26,7 @@
   when: not usr_bin_mkdir.stat.exists
 
 - name: Install gems (this may take a few minutes)
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle install"
+  shell: "{{ rvm_command }} && bundle install"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -28,4 +28,4 @@
     name: apache2
     state: absent
 
-- include: tools.yml
+- include_tasks: tools.yml

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -22,22 +22,6 @@
   apt:
     name: apt-transport-https
 
-- name: Add Node key
-  become: yes
-  apt_key:
-    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
-    state: present
-
-- name: Get distribution codename
-  shell: lsb_release -c --short
-  register: distro_codename
-
-- name: Add Node repository
-  become: true
-  apt_repository:
-    repo: "deb https://deb.nodesource.com/node_10.x {{ distro_codename.stdout }} main"
-    state: present
-
 - name: Remove apache server
   become: true
   apt:

--- a/roles/system/tasks/tools.yml
+++ b/roles/system/tasks/tools.yml
@@ -20,7 +20,6 @@
       - libffi-dev
       - curl
       - libcurl4-openssl-dev
-      - nodejs
       - libpq-dev
       - imagemagick
       - ruby-dev


### PR DESCRIPTION
# References
* consuldemocracy/consuldemocracy#5158
* consuldemocracy/consuldemocracy#5159

**Do not merge until the Consul Democracy 2.1.0 release.**

# Objective
Consul Democracy has added a `.node-version` file in version 2.1.0, and now it installs the version defined there when deploying with Capistrano and installs NPM packages for that version.

So we're doing the same when running the installer.

1. Install `FNM` for the deploy user
2. Install the `nodejs` version defined in consuldemocracy/consuldemocracy using `FNM`.
3. Install the `nodejs` application dependencies defined in consuldemocracy application `package.json` using `NPM`.
4. Update rails commands so the application finds the proper `nodejs` binaries

The `FNM` installer adds the following entry to the `deploy_user` `.bashrc` file:
```
# fnm
export PATH="/home/deploy/.fnm:$PATH"
eval "`fnm env
```

This code loads the NodeJS version defined in the `.node-version` during interactive shells in the same fashion we do with RVM (by loading the ruby version defined in the `.ruby-version` file). 

# Notes
Any `consuldemocracy/consuldemocracy` command that loads the application (rake, rails, delayed_job puma, among others) must have NodeJS binaries available. Otherwise, it crashes even for commands where JS is not required, like `rake secret`.