### PR TITLE
Split Debian tests by Debian version

### DIFF
--- a/.github/workflows/debian-bullseye.yml
+++ b/.github/workflows/debian-bullseye.yml
@@ -1,0 +1,30 @@
+name: debian-bullseye
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ["debian:bullseye"]
+        rails_env: [staging, production]
+    container:
+      image: ${{ matrix.image }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update system packages
+        run: apt-get update -y
+      - name: Install needed packages
+        run: apt-get install -y lsb-release sudo python3-pip openssh-server
+      - name: Install Ansible
+        run: pip3 install ansible
+      - name: Create hosts file
+        run: echo "localhost ansible_connection=local ansible_user=root" > hosts
+      - name: Generate dummy SSH key
+        run: mkdir ~/.ssh && ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+      - name: Run CONSUL DEMOCRACY installer
+        run: ansible-playbook consul.yml -i hosts --extra-vars "env=${{ matrix.rails_env }} domain=localhost errbit=False"

--- a/.github/workflows/debian-buster.yml
+++ b/.github/workflows/debian-buster.yml
@@ -1,4 +1,4 @@
-name: debian
+name: debian-buster
 on:
   push:
     branches:
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ["debian:buster", "debian:bullseye"]
+        image: ["debian:buster"]
         rails_env: [staging, production]
     container:
       image: ${{ matrix.image }}


### PR DESCRIPTION
# References

* #222 

# Objectives

With this change, we will run Debian tests in separate workflows by version, so if one job from a Debian version fails, it does not cancel all the other jobs.

We keep the failing buster tests because the installer works fine on real servers. It only fails in the CI.

# Notes
We can revert this changes when we solve the CI error with the Debian Buster.