### PR TITLE
Set the application timezone

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -7,6 +7,9 @@ server_hostname: "{{ domain | default(ansible_default_ipv4.address) }}"
 # Server Timezone
 timezone: Europe/Madrid
 
+# Consul Democracy Timezone
+application_timezone: "{{ timezone }}"
+
 # General settings
 env: production
 deploy_user: deploy

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -72,6 +72,12 @@
     regexp: '^{{ env }}:\n  # secret_key_base: ""'
     replace: '{{ env }}:\n  secret_key_base: "{{ secret_key_base.stdout }}"'
 
+- name: Update application timezone configuration in secrets.yml
+  replace:
+    path: "{{ shared_dir }}/config/secrets.yml"
+    regexp: '^  # time_zone: ""'
+    replace: '  time_zone: "{{ application_timezone }}"'
+
 - name: Do not force https connection
   replace:
     path: "{{ shared_dir }}/config/secrets.yml"


### PR DESCRIPTION
# References

This PR depends on:
* consuldemocracy/consuldemocracy#5318

#  Objectives
Allow users to set up the application timezone from the installer like we do with the server timezone.