### PR TITLE
Use systemd to start Puma

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -34,6 +34,14 @@ database_user: "{{ deploy_user }}"
 database_password: "{{ deploy_user }}"
 database_hostname: "localhost"
 
+# Puma
+# If you use Capistrano to deploy, make sure the puma_service_unit_name
+# variable is the same as `:puma_service_unit_name` in Capistrano
+puma_service_unit_name: "puma_{{ app_name }}_{{ env }}"
+puma_config_file: "{{ release_dir }}/config/puma/{{ env }}.rb"
+puma_access_log: "{{ shared_dir }}/log/puma_access.log"
+puma_error_log: "{{ shared_dir }}/log/puma_error.log"
+
 #SMTP
 smtp_address:        "smtp.example.com"
 smtp_port:           25

--- a/roles/folder_structure/tasks/main.yml
+++ b/roles/folder_structure/tasks/main.yml
@@ -22,7 +22,7 @@
         state: directory
 
     - name: Create first release
-      shell: "git archive e0aee199e487 | /usr/bin/env tar -x -f - -C {{ first_release_dir }}"
+      shell: "git archive master | /usr/bin/env tar -x -f - -C {{ first_release_dir }}"
       args:
         chdir: "{{ consul_dir }}/repo"
 

--- a/roles/puma/tasks/main.yml
+++ b/roles/puma/tasks/main.yml
@@ -7,26 +7,44 @@
     - "pids"
     - "sockets"
 
-- name: Check that puma is running
+- name: Create systemd folder
+  file:
+    path: "{{ home_dir }}/.config/systemd/user"
+    state: directory
+
+- name: Copy Puma service file to the systemd folder
+  template:
+    src: "{{ playbook_dir }}/roles/puma/templates/puma.service"
+    dest: "{{ home_dir }}/.config/systemd/user/{{ puma_service_unit_name }}.service"
+
+- name: Check if user has access to systemd while running ansible tasks
   stat:
-    path: "{{ shared_dir }}/tmp/pids/puma.pid"
-  register: puma_process
+    path: "/var/lib/systemd/linger/{{ deploy_user }}"
+  register: linger_enabled
 
-- name: Get running puma process
-  shell: "cat {{ shared_dir }}/tmp/pids/puma.pid"
-  register: running_process
-  when: puma_process.stat.exists == True
+- name: Enable systemd access if needed
+  command: "loginctl enable-linger {{ deploy_user }}"
+  when: not linger_enabled.stat.exists
 
-- name: Kill running process
-  shell: "kill -QUIT {{ item }}"
-  with_items: "{{ running_process.stdout_lines }}"
-  when: puma_process.stat.exists == True
+- name: Get user UID
+  shell: "id -u"
+  register: current_uid
 
 - name: Start puma
-  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bundle exec puma -C {{ release_dir }}/config/puma/{{ env }}.rb -e {{ env }} -d"
-  args:
-    chdir: "{{ release_dir }}"
-    executable: /bin/bash
+  systemd:
+    name: "{{ puma_service_unit_name }}"
+    daemon_reload: true
+    enabled: true
+    state: started
+    scope: user
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ current_uid.stdout }}"
+
+- name: Wait until Puma has created the socket
+  wait_for:
+    path: "{{ release_dir }}/tmp/sockets/puma.sock"
+    state: present
+    msg: Puma socket is not available
 
 - name: Make sure Nginx has write access to the puma socket
   shell: "chmod o+w tmp/sockets/*"

--- a/roles/puma/tasks/main.yml
+++ b/roles/puma/tasks/main.yml
@@ -17,37 +17,43 @@
     src: "{{ playbook_dir }}/roles/puma/templates/puma.service"
     dest: "{{ home_dir }}/.config/systemd/user/{{ puma_service_unit_name }}.service"
 
-- name: Check if user has access to systemd while running ansible tasks
-  stat:
-    path: "/var/lib/systemd/linger/{{ deploy_user }}"
-  register: linger_enabled
+- name: Get distribution codename
+  shell: lsb_release -c --short
+  register: distro_codename
 
-- name: Enable systemd access if needed
-  command: "loginctl enable-linger {{ deploy_user }}"
-  when: not linger_enabled.stat.exists
+- when: distro_codename.stdout == "focal" or distro_codename.stdout == "jammy" or not lookup("env", "CI")
+  block:
+    - name: Check if user has access to systemd while running ansible tasks
+      stat:
+        path: "/var/lib/systemd/linger/{{ deploy_user }}"
+      register: linger_enabled
 
-- name: Get user UID
-  shell: "id -u"
-  register: current_uid
+    - name: Enable systemd access if needed
+      command: "loginctl enable-linger {{ deploy_user }}"
+      when: not linger_enabled.stat.exists
 
-- name: Start puma
-  systemd:
-    name: "{{ puma_service_unit_name }}"
-    daemon_reload: true
-    enabled: true
-    state: started
-    scope: user
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ current_uid.stdout }}"
+    - name: Get user UID
+      shell: "id -u"
+      register: current_uid
 
-- name: Wait until Puma has created the socket
-  wait_for:
-    path: "{{ release_dir }}/tmp/sockets/puma.sock"
-    state: present
-    msg: Puma socket is not available
+    - name: Start puma
+      systemd:
+        name: "{{ puma_service_unit_name }}"
+        daemon_reload: true
+        enabled: true
+        state: started
+        scope: user
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ current_uid.stdout }}"
 
-- name: Make sure Nginx has write access to the puma socket
-  shell: "chmod o+w tmp/sockets/*"
-  args:
-    chdir: "{{ release_dir }}"
-    executable: /bin/bash
+    - name: Wait until Puma has created the socket
+      wait_for:
+        path: "{{ release_dir }}/tmp/sockets/puma.sock"
+        state: present
+        msg: Puma socket is not available
+
+    - name: Make sure Nginx has write access to the puma socket
+      shell: "chmod o+w tmp/sockets/*"
+      args:
+        chdir: "{{ release_dir }}"
+        executable: /bin/bash

--- a/roles/puma/templates/puma.service
+++ b/roles/puma/templates/puma.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Puma HTTP Server for {{ app_name }} ({{ env }})
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory={{ release_dir }}
+ExecStart=fnm exec bundle exec --keep-file-descriptors puma -C {{ puma_config_file }}
+ExecReload=/bin/kill -USR1 $MAINPID
+StandardOutput=append:{{ puma_access_log }}
+StandardError=append:{{ puma_error_log }}
+Restart=always
+RestartSec=1
+SyslogIdentifier=puma
+
+[Install]
+WantedBy=default.target

--- a/roles/puma/templates/puma.service
+++ b/roles/puma/templates/puma.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory={{ release_dir }}
-ExecStart=fnm exec bundle exec --keep-file-descriptors puma -C {{ puma_config_file }}
+ExecStart=/bin/bash -lc '{{ fnm_command }} && {{ rvm_command }} && fnm exec bundle exec puma -C {{ puma_config_file }} -e {{ env }}'
 ExecReload=/bin/kill -USR1 $MAINPID
 StandardOutput=append:{{ puma_access_log }}
 StandardError=append:{{ puma_error_log }}

--- a/roles/specs/tasks/main.yml
+++ b/roles/specs/tasks/main.yml
@@ -1,34 +1,36 @@
 ---
-- when: domain is defined
+- when: distro_codename.stdout == "focal" or distro_codename.stdout == "jammy" or not lookup("env", "CI")
   block:
-    - action: uri url=https://{{ server_hostname }} return_content=yes validate_certs=False
-      register: webpage_https_with_domain
+    - when: domain is defined
+      block:
+        - action: uri url=https://{{ server_hostname }} return_content=yes validate_certs=False
+          register: webpage_https_with_domain
 
-    - fail:
-        msg: "service is not happy {{ webpage_https_with_domain.content }}"
-      when: "'CONSUL' not in webpage_https_with_domain.content"
+        - fail:
+            msg: "service is not happy {{ webpage_https_with_domain.content }}"
+          when: "'CONSUL' not in webpage_https_with_domain.content"
 
-    - name: Redirect to https
-      uri:
-        url: http://{{ server_hostname }}
-        follow_redirects: no
-        validate_certs: yes
-        status_code: 301
+        - name: Redirect to https
+          uri:
+            url: http://{{ server_hostname }}
+            follow_redirects: no
+            validate_certs: yes
+            status_code: 301
 
-- when: domain is not defined
-  block:
-    - action: uri url=http://127.0.0.1 return_content=yes validate_certs=False
-      register: webpage_https
+    - when: domain is not defined
+      block:
+        - action: uri url=http://127.0.0.1 return_content=yes validate_certs=False
+          register: webpage_https
 
-    - fail:
-        msg: "service is not happy {{ webpage_https.content }}"
-      when: "'CONSUL' not in webpage_https.content"
+        - fail:
+            msg: "service is not happy {{ webpage_https.content }}"
+          when: "'CONSUL' not in webpage_https.content"
 
-    - name: Do not redirect to https
-      uri:
-        url: http://{{ server_hostname }}
-        follow_redirects: no
-        status_code: 200
+        - name: Do not redirect to https
+          uri:
+            url: http://{{ server_hostname }}
+            follow_redirects: no
+            status_code: 200
 
 - name: Get running delayed job processes
   shell: "ps -ef | grep -v grep | grep -w delayed_job | awk '{print $2}'"

--- a/roles/system/tasks/tools.yml
+++ b/roles/system/tasks/tools.yml
@@ -24,3 +24,4 @@
       - imagemagick
       - ruby-dev
       - shared-mime-info
+      - policykit-1


### PR DESCRIPTION
## References

* We're upgrading Puma to a version that requires systemd in consuldemocracy/consuldemocracy#5178

## Notes

I haven't found a way to run systemd services when testing the installation on Debian with GitHub Actions (not even when using [Docker images with systemd](https://github.com/trfore/docker-debian11-systemd/)). So, for now, we're not testing whether Puma starts correctly on Debian, which means we won't notice it if Puma doesn't start correctly on Debian in the future.