### PR TITLE
Enable graceful appication restarts

### DIFF
--- a/roles/puma/tasks/main.yml
+++ b/roles/puma/tasks/main.yml
@@ -17,6 +17,11 @@
     src: "{{ playbook_dir }}/roles/puma/templates/puma.service"
     dest: "{{ home_dir }}/.config/systemd/user/{{ puma_service_unit_name }}.service"
 
+- name: Copy Puma socket file to the systemd folder
+  template:
+    src: "{{ playbook_dir }}/roles/puma/templates/puma.socket"
+    dest: "{{ home_dir }}/.config/systemd/user/{{ puma_service_unit_name }}.socket"
+
 - name: Get distribution codename
   shell: lsb_release -c --short
   register: distro_codename
@@ -36,9 +41,19 @@
       shell: "id -u"
       register: current_uid
 
+    - name: Enable puma socket activation
+      systemd:
+        name: "{{ puma_service_unit_name }}.socket"
+        daemon_reload: true
+        enabled: true
+        state: started
+        scope: user
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ current_uid.stdout }}"
+
     - name: Start puma
       systemd:
-        name: "{{ puma_service_unit_name }}"
+        name: "{{ puma_service_unit_name }}.service"
         daemon_reload: true
         enabled: true
         state: started

--- a/roles/puma/templates/puma.service
+++ b/roles/puma/templates/puma.service
@@ -5,10 +5,11 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory={{ release_dir }}
-ExecStart=/bin/bash -lc '{{ fnm_command }} && {{ rvm_command }} && fnm exec bundle exec puma -C {{ puma_config_file }} -e {{ env }}'
+ExecStart=/bin/bash -lc '{{ rvm_command }} && bundle exec puma -C {{ puma_config_file }} -e {{ env }}'
 ExecReload=/bin/kill -USR1 $MAINPID
 StandardOutput=append:{{ puma_access_log }}
 StandardError=append:{{ puma_error_log }}
+Environment=EXECJS_RUNTIME=Disabled
 Restart=always
 RestartSec=1
 SyslogIdentifier=puma

--- a/roles/puma/templates/puma.service
+++ b/roles/puma/templates/puma.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Puma HTTP Server for {{ app_name }} ({{ env }})
 After=network.target
+Requires={{ puma_service_unit_name }}.socket
 
 [Service]
 Type=simple

--- a/roles/puma/templates/puma.socket
+++ b/roles/puma/templates/puma.socket
@@ -1,0 +1,20 @@
+[Unit]
+Description=Puma HTTP Server Accept Sockets for {{ app_name }} ({{ env }})
+
+[Socket]
+ListenStream={{ shared_dir }}/tmp/sockets/puma.sock
+
+# Don't let systemd accept the request, wait for Puma to do that.
+# Systemd will start the puma service upon first request if it wasn't started.
+#
+# You might also want to set your Nginx upstream to have a fail_timeout large enough to accomodate your app's
+# startup time.
+Accept=no
+
+ReusePort=true
+Backlog=1024
+
+SyslogIdentifier=puma_socket
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
## References
 
* https://github.com/consuldemocracy/consuldemocracy/pull/5372

## Objectives

Avoid using FNM in the Puma system service ExecStart command, which fixes issues regarding stopping/restarting the service and graceful restarts.

Please take a look at the referenced PR description for more details.




# 