### PR TITLE
Update tests status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CONSUL DEMOCRACY Installer ![Build status](https://github.com/consuldemocracy/installer/workflows/tests/badge.svg)
+# CONSUL DEMOCRACY Installer ![Build status on Ubuntu](https://github.com/consuldemocracy/installer/workflows/ubuntu/badge.svg)
 
 [CONSUL DEMOCRACY](https://github.com/consuldemocracy/consuldemocracy) installer for production environments
 


### PR DESCRIPTION
## Referecences

* We renamed the `tests` workflow to `ubuntu` in commit f346954ea from pull request #190

## Objectives

* Correctly show the status of the test suite in the README file

## Notes

For unknown reasons, the Debian badge shows that the build failed even when it passed, so for now we're only showing the one for Ubuntu.