### PR TITLE
Only use fnm exec when necessary 

### DIFF
--- a/roles/errbit/tasks/main.yml
+++ b/roles/errbit/tasks/main.yml
@@ -146,7 +146,7 @@
     replace: '  errbit_host: "https://{{ errbit_domain }}"'
 
 - name: Restart CONSUL DEMOCRACY
-  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bin/rails restart RAILS_ENV={{ env }}"
+  shell: "{{ rvm_command }} && bin/rails restart RAILS_ENV={{ env }} EXECJS_RUNTIME=Disabled"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -14,7 +14,7 @@
   register: node_version
 
 - name: Install nodejs via fnm
-  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm install {{ node_version.stdout }}"
+  shell: "{{ fnm_command }} && fnm install {{ node_version.stdout }}"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
@@ -24,7 +24,7 @@
   delay: 10
 
 - name: Install Node packages
-  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec npm install --production"
+  shell: "{{ fnm_command }} && fnm exec npm install --production"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash

--- a/roles/queue/tasks/main.yml
+++ b/roles/queue/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Start DelayedJobs queue
-  shell: "{{ fnm_command }} && {{ rvm_command }} && RAILS_ENV={{ env }} fnm exec bin/delayed_job -m -n 2 restart"
+  shell: "{{ rvm_command }} && RAILS_ENV={{ env }} EXECJS_RUNTIME=Disabled bin/delayed_job -m -n 2 restart"
   args:
     executable: /bin/bash
     chdir: "{{ release_dir }}"

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -60,7 +60,7 @@
     replace: '{{ env }}:\n  # secret_key_base: ""\n  server_name: "{{ server_hostname }}"'
 
 - name: Generate secret key
-  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bin/rake secret RAILS_ENV={{ env }}"
+  shell: "{{ rvm_command }} && bin/rake secret RAILS_ENV={{ env }} EXECJS_RUNTIME=Disabled"
   register: secret_key_base
   args:
     chdir: "{{ release_dir }}"
@@ -86,13 +86,13 @@
   when: domain is not defined
 
 - name: Create Database
-  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bin/rake db:migrate RAILS_ENV={{ env }}"
+  shell: "{{ rvm_command }} && bin/rake db:migrate RAILS_ENV={{ env }} EXECJS_RUNTIME=Disabled"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
 
 - name: Load configuration seeds
-  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bin/rake db:seed RAILS_ENV={{ env }}"
+  shell: "{{ rvm_command }} && bin/rake db:seed RAILS_ENV={{ env }} EXECJS_RUNTIME=Disabled"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
@@ -104,7 +104,7 @@
     executable: /bin/bash
 
 - name: Update crontab with whenever
-  shell: "{{ fnm_command }} && {{ rvm_command }} && fnm exec bundle exec whenever --update-crontab {{ app_name }} --set environment={{ env }}"
+  shell: "{{ rvm_command }} && EXECJS_RUNTIME=Disabled bundle exec whenever --update-crontab {{ app_name }} --set environment={{ env }}"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash


### PR DESCRIPTION
## References

* We introduced FNM in pull request #223
* We did similar changes for Capistrano deployments in consuldemocracy/consuldemocracy@bb20e8e2bd

## Objectives

* Simplify the code executing Ruby commands than don't depend on Node.js
* Simplify the code executing Node.js commands than don't depend on Ruby
* Make the commands in the installer more consistent with the commands in Capistrano