### PR TITLE
Use dependabot to update github actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50


### PR DESCRIPTION
## References

* We're doing the exact same thing for the main project in consuldemocracy/consuldemocracy#5611

## Objectives

* Make it easier to maintain our github actions dependencies