### PR TITLE
Add support for Ubuntu 24.04

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Update system packages
         run: apt-get update -y
       - name: Install needed packages
-        run: apt-get install -y lsb-release sudo python3-pip openssh-server ansible
+        run: apt-get install -y lsb-release sudo openssh-server ansible
       - name: Create hosts file
         run: echo "localhost ansible_connection=local ansible_user=root" > hosts
       - name: Generate dummy SSH key

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,15 +18,10 @@ jobs:
         rails_env: [staging, production]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
       - name: Update system packages
         run: sudo apt-get update -y
-      - name: Install OpenSSH
-        run: sudo apt-get install -y openssh-server
-      - name: Install Ansible
-        run: pip3 install ansible
+      - name: Install needed packages
+        run: sudo apt-get install -y openssh-server ansible
       - name: Create hosts file
         run: echo "localhost ansible_connection=local ansible_user=root" > hosts
       - name: Generate dummy SSH key

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,8 @@ jobs:
       matrix:
         platforms: [
           { os: "ubuntu-20.04", errbit: "True" },
-          { os: "ubuntu-22.04", errbit: "False"}
+          { os: "ubuntu-22.04", errbit: "False"},
+          { os: "ubuntu-24.04", errbit: "False"}
         ]
         rails_env: [staging, production]
     steps:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A remote server with one of the supported distributions:
 
 - Ubuntu 20.04 x64
 - Ubuntu 22.04 x64
+- Ubuntu 24.04 x64
 - Debian Bullseye x64
 - Debian Bookworm x64
 


### PR DESCRIPTION
## Objectives

* Point out that we now officially support installing Consul Democracy on the latest Ubuntu LTS version

## Notes

We haven't had to change anything in the installer; we've only had to change the github actions workflow.