### PR TITLE
Fix the import of RVM GPG keys

### DIFF
--- a/galaxy/rvm.ruby/tasks/rvm.yml
+++ b/galaxy/rvm.ruby/tasks/rvm.yml
@@ -27,7 +27,7 @@
   check_mode: False
   with_items: '{{ rvm1_gpg_key_servers }}'
   register: gpg_import
-  when: not ansible_check_mode and rvm1_gpg_keys != '' and (gpg_import is not defined or gpg_import.rc != 0)
+  when: not ansible_check_mode and rvm1_gpg_keys != '' and (gpg_import is not defined or (gpg_import.rc is defined and gpg_import.rc != 0))
   ignore_errors: True
 
 - name: Was GPG import from keyservers succesfull?


### PR DESCRIPTION
## References

* This was consistently failing on our CI with Ubuntu 22.04 and Ubuntu 24.04 since a few weeks ago; for example in our [test run 392, job 2](https://github.com/consuldemocracy/installer/actions/runs/11180060085/job/31082011569)

## Objectives

* Avoid an error with RVM GPG keys when running the installer in our CI