### PR TITLE
Remove support for Ubuntu 20.04

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         platforms: [
-          { os: "ubuntu-20.04", errbit: "True" },
           { os: "ubuntu-22.04", errbit: "False"},
           { os: "ubuntu-24.04", errbit: "False"}
         ]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ It will also create a `deploy` user to install these libraries
 
 A remote server with one of the supported distributions:
 
-- Ubuntu 20.04 x64
 - Ubuntu 22.04 x64
 - Ubuntu 24.04 x64
 - Debian Bullseye x64


### PR DESCRIPTION
## Objectives

* Make it clear that we don't support Ubuntu 20.04 since it's about to be deprecated

## Notes

With this commit, we no longer test that Errbit is correctly installed. We might add it to other workflows in the future.