### PR TITLE
Align SyslogIdentifier in puma.service template with Capistrano defaults

### DIFF
--- a/roles/puma/templates/puma.service
+++ b/roles/puma/templates/puma.service
@@ -17,7 +17,7 @@ Restart=on-failure
 StandardOutput=append:{{ puma_access_log }}
 StandardError=append:{{ puma_error_log }}
 
-SyslogIdentifier=puma
+SyslogIdentifier={{ puma_service_unit_name }}
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## References
Related PR's: consuldemocracy/consuldemocracy#6022

## Objectives
Replace the hardcoded SyslogIdentifier=puma with a dynamic value using the "puma_service_unit_name" variable. This ensures consistency with the capistrano3-puma gem, which uses the same value to name systemd units and logs (e.g. "puma_consul_production").

This aligns the installer with the capistrano3-puma configuration used in the consuldemocracy application, avoiding mismatches or duplicated identifiers across deployments.