### PR TITLE
Add Ubuntu 26.04 support

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,8 @@ jobs:
       matrix:
         platforms: [
           { os: "ubuntu-22.04", errbit: "False"},
-          { os: "ubuntu-24.04", errbit: "False"}
+          { os: "ubuntu-24.04", errbit: "False"},
+          { os: "ubuntu-26.04", errbit: "False"}
         ]
         rails_env: [staging, production]
     steps:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A remote server with one of the supported distributions:
 
 - Ubuntu 22.04 x64
 - Ubuntu 24.04 x64
+- Ubuntu 26.04 x64
 - Debian Bullseye x64
 - Debian Bookworm x64
 - Debian Trixie x64

--- a/roles/puma/tasks/main.yml
+++ b/roles/puma/tasks/main.yml
@@ -22,7 +22,7 @@
     src: "{{ playbook_dir }}/roles/puma/templates/puma.socket"
     dest: "{{ home_dir }}/.config/systemd/user/{{ puma_service_unit_name }}.socket"
 
-- when: ansible_distribution_release in ["jammy", "noble"] or lookup("env", "CI") != "true"
+- when: ansible_distribution_release in ["jammy", "noble", "resolute"] or lookup("env", "CI") != "true"
   block:
     - name: Check if user has access to systemd while running ansible tasks
       stat:

--- a/roles/specs/tasks/main.yml
+++ b/roles/specs/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- when: ansible_distribution_release in ["jammy", "noble"] or lookup("env", "CI") != "true"
+- when: ansible_distribution_release in ["jammy", "noble", "resolute"] or lookup("env", "CI") != "true"
   block:
     - when: domain is defined
       block:

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -16,12 +16,6 @@
   # since it's not production, ok if the packages are a bit out-of-date when running tests in exchange for faster builds
   when: lookup("env", "CI") != "true"
 
-# https://askubuntu.com/a/211531/501568
-- name: Install HTTPS package for Aptitude
-  become: true
-  apt:
-    name: apt-transport-https
-
 - name: Remove apache server
   become: true
   apt:

--- a/roles/system/tasks/tools.yml
+++ b/roles/system/tasks/tools.yml
@@ -9,7 +9,7 @@
       - tmux
       - vim
       - htop
-      - git-core
+      - git
       - gpg
       - wget
       - zlib1g-dev


### PR DESCRIPTION
## Objectives

* Point out that we now officially support installing Consul Democracy on the latest Ubuntu LTS version

## Notes

- Adds `ubuntu-26.04` to the GitHub Actions matrix and documents Ubuntu 26.04 in the README.
- Includes the `resolute` codename in Ubuntu-specific task conditions so CI runs the same steps as on 22.04 and 24.04.
- Removes obsolete `apt-transport-https` and renames `git-core` to `git`.